### PR TITLE
Use Mix.Compilers.Erlang.compile_entries/6

### DIFF
--- a/example/myapp/mix.exs
+++ b/example/myapp/mix.exs
@@ -11,7 +11,10 @@ defmodule MyApp.MixProject do
       xref_ignores: [:ct, :eunit],
       deps: deps(),
       erlc_options: erlc_options(Mix.env()),
-      erlc_paths: erlc_paths(Mix.env())
+      erlc_paths: erlc_paths(Mix.env()),
+      compilers: [:erlydtl, :gpb | Mix.compilers()],
+      erlydtl_options: [compiler_options: [:debug_info]],
+      gpb_config: [{"proto/x.proto", [:include_as_lib, i: ~c"proto", o: ~c"src"]}]
     ]
   end
 
@@ -25,7 +28,9 @@ defmodule MyApp.MixProject do
   def deps do
     [
       #{:mix_erl, git: "https://github.com/saleyn/mix-erl", branch: "main", runtime: false},
-      {:mix_erl, path: "../../", runtime: false}
+      {:mix_erl, path: "../../", runtime: false},
+      {:erlydtl, github: "erlydtl/erlydtl"},
+      {:gpb, "~> 4.21"}
     ]
   end
 

--- a/example/myapp/mix.lock
+++ b/example/myapp/mix.lock
@@ -1,5 +1,7 @@
 %{
   "cf": {:hex, :cf, "0.2.2", "7f2913fff90abcabd0f489896cfeb0b0674f6c8df6c10b17a83175448029896c", [:rebar3], [], "hexpm", "48283b3019bc7fad56e7b23028a5da4d3e6cd598a553ab2a99a2153bf5f19b21"},
   "cth_readable": {:hex, :cth_readable, "1.6.0", "a38fa178651da02a9279d6604c542f47b8fda629bf1a90873dd70d94918aa1f8", [:rebar3], [{:cf, "~> 0.2.1", [hex: :cf, repo: "hexpm", optional: false]}], "hexpm", "901e52632b51d5002ffa6d4c89de75a86ed1c95aa32fa1cde04f56e13e0e0599"},
+  "erlydtl": {:git, "https://github.com/erlydtl/erlydtl.git", "55d93eb3d7056e627f0d38897302706b50b22f34", []},
+  "gpb": {:hex, :gpb, "4.21.3", "99cbd5bce894e9287a8f351210afdcd9d4b413087118a0d738b12a2d67d97591", [:make, :rebar3], [], "hexpm", "f31bf9ef24450c978e2010bcec12272049e14f122511a7ae1488aeba8a835158"},
   "mix_erl": {:git, "https://github.com/saleyn/mix-erl", "6159a0948feb3e00594f6814ba64a25147c3e9dc", [branch: "main"]},
 }

--- a/example/myapp/proto/x.proto
+++ b/example/myapp/proto/x.proto
@@ -1,0 +1,5 @@
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+}

--- a/example/myapp/src/myapp.erl
+++ b/example/myapp/src/myapp.erl
@@ -1,6 +1,6 @@
 -module(myapp).
 
--export([add/2, subtract/2]).
+-export([add/2, subtract/2, welcome/0]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -11,6 +11,13 @@ add(A, B) when is_number(A), is_number(B) ->
 
 subtract(A, B) when is_number(A), is_number(B) ->
   A - B.
+
+welcome() ->
+    welcome_dtl:render([
+        {name, "Johnny"},
+        {friends, [<<"Frankie Lee">>, <<"Judas Priest">>]},
+        {primes, [1, 2, "3", <<"5">>]}
+    ]).
 
 -ifdef(EUNIT).
 

--- a/example/myapp/templates/welcome.dtl
+++ b/example/myapp/templates/welcome.dtl
@@ -1,0 +1,9 @@
+Welcome back, {{ name }}!
+
+You have {{ friends|length }} friends: {{ friends|join:", " }}
+
+Have some primes:
+{# this is exciting #}
+{% for i in primes %}
+   {{ i }}
+{% endfor %}

--- a/lib/mix/tasks/compile/erlydtl.ex
+++ b/lib/mix/tasks/compile/erlydtl.ex
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.Compile.Erlydtl do
       preload.()
     end
 
-    compile(manifest, entries, opts, callback)
+    compile_entries(manifest, entries, :dtl, :beam, opts, callback)
   end
 
   defp extract_entries(src_dir, src_ext, dest_dir, dest_ext, force) do

--- a/lib/mix/tasks/compile/gpb.ex
+++ b/lib/mix/tasks/compile/gpb.ex
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Compile.Gpb do
     end
 
     Path.join(Mix.Project.manifest_path(), "compile.gpb")
-    |> compile(entries, opts, callback)
+    |> compile_entries(entries, :proto, :erl, opts, callback)
   end
 
   defp result(:ok), do: {:ok, [], []}
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.Compile.Gpb do
 
   defp options(config, input) do
     Enum.find_value(config, [], fn {files, opts} ->
-      Enum.member?(files, input) && opts
+      List.wrap(files) |> Enum.member?(input) && opts
     end)
   end
 end


### PR DESCRIPTION
Use compile_entries/6 instead of obsoleted compile/4 in gpb and erlydtl compilers.
Add example of erlydtl/gpb compilers usage to demo app.